### PR TITLE
Declare descr_device and descr_config as static const to satisfy gcc.

### DIFF
--- a/usbtinyisp/usb.c
+++ b/usbtinyisp/usb.c
@@ -138,7 +138,7 @@ static	byte_t	string_langid [] PROGMEM =
 #endif
 
 // Device Descriptor
-static	byte_t	descr_device [18] PROGMEM =
+static	const byte_t	descr_device [18] PROGMEM =
 {
 	18,				// bLength
 	DESCRIPTOR_TYPE_DEVICE,		// bDescriptorType
@@ -157,7 +157,7 @@ static	byte_t	descr_device [18] PROGMEM =
 };
 
 // Configuration Descriptor
-static	byte_t	descr_config [] PROGMEM =
+static	const byte_t	descr_config [] PROGMEM =
 {
 	9,				// bLength
 	DESCRIPTOR_TYPE_CONFIGURATION,	// bDescriptorType


### PR DESCRIPTION
GCC-AVR wants descr_device and descr_config to be const.